### PR TITLE
Added dependencies to message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,9 @@ target_link_libraries(importance_sampling grasp_detector grasp_hypothesis ${catk
 target_link_libraries(test_cnn caffe_classifier cloud_camera hand_search handle_search learning plot ${PCL_LIBRARIES})
 
 
+add_dependencies(cloud_camera ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(grasp_hypothesis ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
 #############
 ## Install ##
 #############


### PR DESCRIPTION
Added dependencies to message, as defined in ROS answer "Compiling node and generating message in the same package" :

http://answers.ros.org/question/64448/trouble-with-catkin-compiling-node-and-generating-messages-in-same-package/?answer=64469#post-id-64469

Also, you can check the Jade API for defining message in the same package : 
http://docs.ros.org/jade/api/catkin/html/howto/format2/building_msgs.html (at the bottom)

this will resolve the issue #1 
